### PR TITLE
fix: remove multiple export default

### DIFF
--- a/app/pages/ChallengeList.tsx
+++ b/app/pages/ChallengeList.tsx
@@ -21,7 +21,7 @@ type Props = {
   navigation: any
 }
 
-export default class ChallengeList extends Component<Props> {
+export class ChallengeList extends Component<Props> {
   render() {
     const { navigation } = this.props
 


### PR DESCRIPTION
I couldn't set @ys1111 as reviewer.

A build error happened when I run `npm start' because of "multiple export default".
